### PR TITLE
Fixed removeItem()

### DIFF
--- a/src/NgGrid.ts
+++ b/src/NgGrid.ts
@@ -275,9 +275,13 @@ export class NgGrid {
 	}
 	
 	public removeItem(ngItem: NgGridItem): void {
+		this._removeFromGrid(ngItem);
 		for (var x in this._items)
 			if (this._items[x] == ngItem)
-				this._items = this._items.splice(x, 1);
+				this._items.splice(x, 1);
+
+		// Update position of all items
+		this._items.forEach((item) => item.recalculateSelf());
 	}
 	
 	//	Private methods


### PR DESCRIPTION
Hey, I fixed `removeItem()` because `splice()` works inplace and returns removed elements, so it worked exactly the other way around.
Also running `_removeFromGrid()` and `recalculateSelf()` on all elements was necessary I think.