### PR TITLE
Fixed touch event detection

### DIFF
--- a/src/NgGrid.ts
+++ b/src/NgGrid.ts
@@ -819,9 +819,8 @@ export class NgGrid {
 	}
 	
 	private _getMousePosition(e: any): {left: number, top: number} {
-		if (e.originalEvent && e.originalEvent.touches) {
-			var oe = e.originalEvent;
-			e = oe.touches.length ? oe.touches[0] : oe.changedTouches[0];
+		if (e instanceof TouchEvent) {
+			e = e.touches.length > 0 ? e.touches[0] : e.changedTouches[0];
 		}
 		
 		var refPos = this._ngEl.nativeElement.getBoundingClientRect();


### PR DESCRIPTION
Hey, one more change. Detecting touch events is easier and probably more reliable with `e instanceof TouchEvent`.
The method with `originalEvent` didn't work for me (property `originalEvent` doesn't exist on `TouchEvent` class).
I'm not sure if we can completely remove it or it handled some other situation that I haven't tested.