### PR TITLE
Update readme for latest angular2-quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,11 @@ As of the Angular 2 Release Candidate you will now need to have the following in
 
 ```
 map: {
-    'angular2-grid': 'node_modules/angular2-grid/dist/NgGrid'
+    'angular2-grid': 'node_modules/angular2-grid/dist'
+}
+
+packages: {
+    'angular2-grid': { main: 'main.js',  defaultExtension: 'js' }
 }
 ```
 


### PR DESCRIPTION
The current instructions result in a NgGrid 404 if applied to the latest Quickstart project. Related: Issue #99 