### PR TITLE
Update NgGrid.ts | Pushing to 0.8.4 | Dependencies updated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-grid",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "homepage": "https://github.com/BTMorton/angular2-grid",
   "authors": [
     "Ben Morton <ben.morton91@gmail.com> (http://bmorton.co.uk/)",
@@ -34,6 +34,6 @@
     "url": "git://github.com/BTMorton/angular2-grid.git"
   },
   "dependencies": {
-    "bootstrap": "~3.3.5"
+    "bootstrap": "~3.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-grid",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "A grid-based drag/drop/resize directive plugin for Angular 2",
   "main": "dist/main.js",
   "typings": "dist/main.d.ts",
@@ -29,6 +29,7 @@
     "Chris Morabito (https://github.com/morabitowoolpert)",
     "Carlos Esteban Lopez Jaramillo (https://github.com/Luchillo)",
     "Niklas Berg (https://github.com/nkholski)"
+    "Wouter (https://github.com/wuhkuh)"
   ],
   "license": "MIT",
   "bugs": {
@@ -44,12 +45,12 @@
     "dist/interfaces/*"
   ],
   "peerDependencies": {
-    "@angular/core": "^2.0.0-rc.0"
+    "@angular/core": "^2.0.0-rc.4"
   },
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.0",
-    "@angular/core": "^2.0.0-rc.0",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.0",
+    "@angular/common": "^2.0.0-rc.4",
+    "@angular/core": "^2.0.0-rc.4",
+    "@angular/platform-browser-dynamic": "^2.0.0-rc.4",
     "bower": "^1.7.9",
     "del": "^2.2.0",
     "es6-shim": "^0.35.1",
@@ -73,7 +74,7 @@
     "rxjs": "5.0.0-beta.6",
     "systemjs": "^0.19.29",
     "typescript": "^1.8.10",
-    "typings": "^1.0.4",
+    "typings": "^1.3.1",
     "zone.js": "^0.6.12"
   },
   "dependencies": {}

--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -461,12 +461,8 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 			if (this.resizeEnable && item.canResize(e) != null) {
 				this._resizeStart(e);
 				return false;
-			} else if (this.dragEnable && item.canDrag(e)) {
-				this._dragStart(e);
-				return false;
 			}
 		}
-
 		return true;
 	}
 
@@ -519,6 +515,16 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	}
 
 	private _onMouseMove(e: any): void {
+		var mousePos = this._getMousePosition(e);
+		var item = this._getItemFromPosition(mousePos);
+		
+		if (item != null) {
+		    if (e.buttons == 1 && !this.isDragging && !this.isResizing && this.dragEnable && item.canDrag(e)) {
+		        this._dragStart(e);
+		        return false;
+		    }
+		}
+		
 		if (e.buttons == 0 && this.isDragging) {
 			this._dragStop(e);
 		} else if (e.buttons == 0 && this.isResizing) {

--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -792,13 +792,16 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 			}
 			
 			if (shouldSave) {
-				collisions[0].savePosition(itemPos);
+				const newItemPos = this._fixGridPosition(itemPos, itemDims);
+				collisions[0].savePosition(newItemPos.col, newItemPos.row);
 			} else {
-				collisions[0].setGridPosition(itemPos);
+		                const newItemPos = this._fixGridPosition(itemPos, itemDims);
+		                collisions[0].setGridPosition(newItemPos.col, newItemPos.row);
 			}
 			this._fixGridCollisions(itemPos, itemDims, shouldSave);
 			this._addToGrid(collisions[0]);
 			collisions[0].onCascadeEvent();
+			this._cascadeGrid();
 		}
 	}
 	

--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -1017,7 +1017,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 								}
 							}
 
-							if (lowest != itemPos.row) {	//	If the item is not already on this row move it up
+							if (lowest != itemPos.row && this._isWithinBoundsY({c, lowest}, itemDims))) {	//	If the item is not already on this row move it up
 								this._removeFromGrid(item);
 								
 								if (shouldSave) {
@@ -1072,11 +1072,11 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 								}
 							}
 
-							if (lowest != itemPos.col) {	//	If the item is not already on this col move it up
+							if (lowest != itemPos.col && this._isWithinBoundsX({lowest, r}, itemDims))) {	//	If the item is not already on this col move it up
 								this._removeFromGrid(item);
 								
 								if (shouldSave) {
-									item.savePosition({ col: c, row: lowest });
+									item.savePosition({ col: lowest, row: r });
 								} else {
 									item.setGridPosition({ col: lowest, row: r });
 								}


### PR DESCRIPTION
- Fixed mouseDown and mouseMove events. Dragging, resizing, and clicking the items work properly now. Closes #81.
- Fixed out-of-boundary pushing when dropping a GridItem. Fixed out-of-boundary pushing when GridItems are larger than the standard size.
  Closes #107.
- Fixed 'shouldSave' for left and right cascading.

Package changes:
- Pushed version to 0.8.4.

Dependencies:
- Angular to RC4
- Typings to 1.3.1