### PR TITLE
Fixes dragging and resizing issues

### DIFF
--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -545,6 +545,15 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 
 	private _drag(e: any): void {
 		if (this.isDragging) {
+		        if (window.getSelection) {
+		            if (window.getSelection().empty) {
+		                window.getSelection().empty();
+		            } else if (window.getSelection().removeAllRanges) {
+		                window.getSelection().removeAllRanges();
+		            }
+		        } else if (document.selection) {
+		            document.selection.empty();
+		        };
 			var mousePos = this._getMousePosition(e);
 			var newL = (mousePos.left - this._posOffset.left);
 			var newT = (mousePos.top - this._posOffset.top);
@@ -585,6 +594,15 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 
 	private _resize(e: any): void {
 		if (this.isResizing) {
+		        if (window.getSelection) {
+		            if (window.getSelection().empty) {
+		                window.getSelection().empty();
+		            } else if (window.getSelection().removeAllRanges) {
+		                window.getSelection().removeAllRanges();
+		            }
+		        } else if (document.selection) {
+		            document.selection.empty();
+		        };
 			var mousePos = this._getMousePosition(e);
 			var itemPos = this._resizingItem.getPosition();
 			var itemDims = this._resizingItem.getDimensions();


### PR DESCRIPTION
Fixes dragging and resizing issues when something is selected inside the grid item.

Please REVIEW! I am unable to test document.selection at this moment, so please double-check before merging to your repository.
Consider moving it to your dragStart and resizeStart functions, as I purely upload a hotfix that works. 

It might be more resource-efficient to move it to the xStart functions, but remember that if you drag the NgGridItem it might select the parts inside, and breaking it again while moving.

Therefore, we need testing to make sure this is as optimized as it can be.

This fixes #125.