### PR TITLE
Add "payload" as a property of NgGridItemEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Each event will also provide the following object to any callback functions:
 
 ```javascript
 interface NgGridItemEvent {
+    payload: any,   //  The item's optional custom payload (string/number/object) to be used to identify the item for serialization
     col: number,    //  The item's column position within the grid
     row: number,    //  The item's row position within the grid
     sizex: number,  //  The item's column size within the grid

--- a/src/interfaces/INgGrid.ts
+++ b/src/interfaces/INgGrid.ts
@@ -43,6 +43,7 @@ export interface NgGridItemConfig {
 }
 
 export interface NgGridItemEvent {
+	payload: any,
 	col: number;
 	row: number;
 	sizex: number;


### PR DESCRIPTION
The "payload" optional property of a NgGridItem config is included when creating an NgGridItemEvent as it can be seen here: https://github.com/BTMorton/angular2-grid/blob/f2421647ca7a4e3683f75ec1e35549f21a57139b/src/directives/NgGridItem.ts#L372.
However this property was not declared in the interface neither in the README doc.