### PR TITLE
Upgrade @angular & typescript deps & add aot config

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@ var typescript = require('gulp-typescript');
 var uglify = require('gulp-uglify');
 var concat = require('gulp-concat');
 var rename = require('gulp-rename');
+var exec = require('child_process').exec;
 var symlink = require('gulp-symlink');
 var sourcemaps = require('gulp-sourcemaps');
 var runSequence = require('run-sequence');
@@ -31,6 +32,14 @@ var PATHS = {
 
 gulp.task('clean', function (done) {
 	return del(['dist'], done);
+});
+
+gulp.task('ngc', function(done) {
+	exec('ngc -p tsconfig.aot.json', function (err, stdout, stderr) {
+	    console.log(stdout);
+	    console.log(stderr);
+	    done(err);
+	});
 });
 
 gulp.task('ts', function () {
@@ -97,6 +106,10 @@ gulp.task('clean', function(done) {
 
 gulp.task('build', ['clean'], function() {
 	return gulp.start('libs', 'html', 'css', 'ts');
+});
+
+gulp.task('build-aot', ['clean'], function() {
+	return gulp.start('css', 'ngc');
 });
 
 gulp.task('rebuild', ['clean'], function() {

--- a/package.json
+++ b/package.json
@@ -47,15 +47,19 @@
     "dist/modules/*"
   ],
   "peerDependencies": {
-    "@angular/core": "2.0.0"
+    "@angular/core": "2.1.1"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
-    "@angular/forms": "2.0.0",
-    "@angular/platform-browser": "2.0.0",
-    "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/common": "2.1.1",
+    "@angular/compiler": "2.1.1",
+    "@angular/compiler-cli": "2.1.1",
+    "@angular/core": "2.1.1",
+    "@angular/forms": "2.1.1",
+    "@angular/platform-browser": "2.1.1",
+    "@angular/platform-browser-dynamic": "2.1.1",
+    "@types/core-js": "^0.9.35",
+    "@types/jasmine": "^2.5.38",
+    "@types/node": "0.0.2",
     "bower": "^1.7.9",
     "core-js": "^2.4.1",
     "del": "^2.2.0",
@@ -79,7 +83,7 @@
     "run-sequence": "^1.2.1",
     "rxjs": "5.0.0-beta.12",
     "systemjs": "^0.19.29",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.10",
     "typings": "^1.3.1",
     "zone.js": "^0.6.21"
   }

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -1,0 +1,34 @@
+{
+	"compilerOptions": {
+		"target": "ES5",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"sourceMap": true,
+		"emitDecoratorMetadata": true,
+		"experimentalDecorators": true,
+		"noImplicitAny": false,
+		"declaration": true,
+		"rootDir": "./src",
+		"outDir": "./dist",
+		"typeRoots": [
+            "node_modules/@types",
+            "typings"
+        ],
+        "types": [
+        	"core-js",
+        	"node",
+        	"jasmine"
+        ]
+	},
+	"exclude": [
+		"bower",
+		"node_modules"
+	],
+	"files": [
+		"./src/main.ts"
+	],
+	"angularCompilerOptions": {
+        "strictMetadataEmit": true,
+        "skipTemplateCodegen": true
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"noImplicitAny": false,
-		"declarationFiles": true,
+		"declaration": true,
 		"rootDir": "./src"
 	},
 	"exclude": [


### PR DESCRIPTION
This patch should take care of providing the `*.metadata.json` files needed for aot. I'm not 100% sure it's compatible with how you publish, but it looks like it should work.