### PR TITLE
Added Feature #238 allow gridItem overlaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,61 +1,62 @@
 {
-  "name": "angular2-grid",
-  "private": true,
-  "description": "A grid-based drag/drop/resize directive plugin for Angular 2",
-  "scripts": {
-    "cleanup": "rimraf dist/bundles dist/components dist/directives dist/interfaces dist/modules dist/main.d.ts dist/main.metadata.json dist/main.js dist/main.js.map dist/LICENSE dist/README.md",
-    "bundling": "rollup -c",
-    "minify": "uglifyjs dist/bundles/NgGrid.umd.js --screw-ie8 --compress --mangle --comments --output dist/bundles/NgGrid.umd.min.js",
-    "copy": "copyfiles -f LICENSE README.md src/*.css dist",
-    "build": "npm run cleanup && ngc && npm run bundling && npm run minify && npm run copy"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/BTMorton/angular2-grid.git"
-  },
-  "keywords": [
-    "angular",
-    "angular2",
-    "grid",
-    "web-components"
-  ],
-  "author": "Ben Morton <ben.morton91@gmail.com> (http://bmorton.co.uk/)",
-  "contributors": [
-    "Martin Sikora (https://github.com/martinsik)",
-    "Daniel Pastor de la Fuenta (https://github.com/aebsubis)",
-    "Frederik Schubert (https://github.com/frederikschubert)",
-    "Matthew de Nobrega (https://github.com/matthewdenobrega)",
-    "Alex (https://github.com/lifecoderua)",
-    "pocmanu (https://github.com/pocmanu)",
-    "Chris Morabito (https://github.com/morabitowoolpert)",
-    "Carlos Esteban Lopez Jaramillo (https://github.com/Luchillo)",
-    "Niklas Berg (https://github.com/nkholski)",
-    "Wouter (https://github.com/wuhkuh)",
-    "Brian Ellis (https://github.com/OnlyAGhost)"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/BTMorton/angular2-grid/issues"
-  },
-  "homepage": "https://github.com/BTMorton/angular2-grid",
-  "files": [
-    "dist/NgGrid*",
-    "dist/js/",
-    "dist/bundles/",
-    "dist/aot/",
-    "dist/typings/"
-  ],
-  "devDependencies": {
-    "@angular/core": "^2.4.0",
-    "@angular/compiler": "^2.4.0",
-    "@angular/compiler-cli": "^2.4.0",
-    "copyfiles": "^1.0.0",
-    "reflect-metadata": "^0.1.8",
-    "rimraf": "^2.5.4",
-    "rollup": "^0.37.0",
-    "rxjs": "^5.0.1",
-    "typescript": "~2.0.10",
-    "uglify-js": "^2.7.5",
-    "zone.js": "^0.7.2"
-  }
+    "name": "angular2-grid",
+    "private": true,
+    "description": "A grid-based drag/drop/resize directive plugin for Angular 2",
+    "scripts": {
+        "cleanup": "rimraf dist/bundles dist/components dist/directives dist/interfaces dist/modules dist/main.d.ts dist/main.metadata.json dist/main.js dist/main.js.map dist/LICENSE dist/README.md",
+        "bundling": "rollup -c",
+        "minify": "uglifyjs dist/bundles/NgGrid.umd.js --screw-ie8 --compress --mangle --comments --output dist/bundles/NgGrid.umd.min.js",
+        "copy": "copyfiles -f LICENSE README.md src/*.css dist",
+        "build": "npm run cleanup && ngc && npm run bundling && npm run minify && npm run copy"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/BTMorton/angular2-grid.git"
+    },
+    "keywords": [
+        "angular",
+        "angular2",
+        "grid",
+        "web-components"
+    ],
+    "author": "Ben Morton <ben.morton91@gmail.com> (http://bmorton.co.uk/)",
+    "contributors": [
+        "Arup Banerjee <arup@alanaamy.net> (https://www.alanaamy.net/)",
+        "Martin Sikora (https://github.com/martinsik)",
+        "Daniel Pastor de la Fuenta (https://github.com/aebsubis)",
+        "Frederik Schubert (https://github.com/frederikschubert)",
+        "Matthew de Nobrega (https://github.com/matthewdenobrega)",
+        "Alex (https://github.com/lifecoderua)",
+        "pocmanu (https://github.com/pocmanu)",
+        "Chris Morabito (https://github.com/morabitowoolpert)",
+        "Carlos Esteban Lopez Jaramillo (https://github.com/Luchillo)",
+        "Niklas Berg (https://github.com/nkholski)",
+        "Wouter (https://github.com/wuhkuh)",
+        "Brian Ellis (https://github.com/OnlyAGhost)"
+    ],
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/BTMorton/angular2-grid/issues"
+    },
+    "homepage": "https://github.com/BTMorton/angular2-grid",
+    "files": [
+        "dist/NgGrid*",
+        "dist/js/",
+        "dist/bundles/",
+        "dist/aot/",
+        "dist/typings/"
+    ],
+    "devDependencies": {
+        "@angular/core": "^2.4.0",
+        "@angular/compiler": "^2.4.0",
+        "@angular/compiler-cli": "^2.4.0",
+        "copyfiles": "^1.0.0",
+        "reflect-metadata": "^0.1.8",
+        "rimraf": "^2.5.4",
+        "rollup": "^0.37.0",
+        "rxjs": "^5.0.1",
+        "typescript": "~2.0.10",
+        "uglify-js": "^2.7.5",
+        "zone.js": "^0.7.2"
+    }
 }

--- a/src/NgGrid.css
+++ b/src/NgGrid.css
@@ -1,26 +1,26 @@
 .grid {
-	background-color: #efefef;
-	transform-origin: top center;
-	transition: transform 0.5s;
+    background-color: #efefef;
+    transform-origin: top center;
+    transition: transform 0.5s;
 }
 
 .grid-item {
-	background-color: #ffffff;
-	-webkit-transition: width 0.25s, height 0.25s, transform 0.5s;
-	-moz-transition: width 0.25s, height 0.25s, transform 0.5s;
-	-o-transition: width 0.25s, height 0.25s, transform 0.5s;
-	transition: width 0.25s, height 0.25s, transform 0.5s;
-	overflow: hidden;
+    background-color: #ffffff;
+    -webkit-transition: width 0.25s, height 0.25s, transform 0.5s;
+    -moz-transition: width 0.25s, height 0.25s, transform 0.5s;
+    -o-transition: width 0.25s, height 0.25s, transform 0.5s;
+    transition: width 0.25s, height 0.25s, transform 0.5s;
+    overflow: hidden;
 }
 
-.grid-item:active, .grid-item.moving {
-	z-index: 2;
-	-webkit-transition: none;
-	-moz-transition: none;
-	-o-transition: none;
-	transition: none;
+.grid-item:active,
+.grid-item.moving {
+    -webkit-transition: none;
+    -moz-transition: none;
+    -o-transition: none;
+    transition: none;
 }
 
 .grid-placeholder {
-	background-color: rgba(0, 0, 0, 0.3);
+    background-color: rgba(0, 0, 0, 0.3);
 }

--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -45,6 +45,8 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	public cascade: string = 'up';
 	public minWidth: number = 100;
 	public minHeight: number = 100;
+	public zIndex: number = 1;
+	public allowOverlap: boolean = false;
 
 	//	Private variables
 	private _items: Array<NgGridItem> = [];
@@ -97,6 +99,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 		maintain_ratio: false,
 		prefer_new: false,
 		zoom_on_drag: false,
+		allowOverlap: false
 	};
 	private _config = NgGrid.CONST_DEFAULT_CONFIG;
 
@@ -208,6 +211,9 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 						this._maxCols = this._getContainerColumns();
 					}
 					break;
+				case 'allow_overlap':
+					this.allowOverlap = val ? true : false;
+					break;					
 			}
 		}
 
@@ -344,6 +350,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 		}
 
 		if (this._destroyed) return;
+		if(this.allowOverlap) return;
 
 		this._cascadeGrid();
 		this._updateSize();
@@ -809,6 +816,9 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	}
 
 	private _fixGridCollisions(pos: NgGridItemPosition, dims: NgGridItemSize): void {
+		if(this.allowOverlap) {
+			return;
+		}
 		while (this._hasGridCollision(pos, dims)) {
 			const collisions: Array<NgGridItem> = this._getCollisions(pos, dims);
 
@@ -851,6 +861,9 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 
 	private _cascadeGrid(pos?: NgGridItemPosition, dims?: NgGridItemSize): void {
 		if (this._destroyed) return;
+		if(this.allowOverlap) {
+			return;
+		}		
 		if (pos && !dims) throw new Error('Cannot cascade with only position and not dimensions');
 
 		if (this.isDragging && this._draggingItem && !pos && !dims) {
@@ -1059,6 +1072,9 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	}
 
 	private _addToGrid(item: NgGridItem): void {
+		if( (this.isDragging || this.isResizing) && this.allowOverlap) {
+			return;
+		}
 		let pos: NgGridItemPosition = item.getGridPosition();
 		const dims: NgGridItemSize = item.getSize();
 

--- a/src/directives/NgGridItem.ts
+++ b/src/directives/NgGridItem.ts
@@ -115,6 +115,7 @@ export class NgGridItem implements OnInit, OnDestroy {
 
 	public onResizeStartEvent(): void {
 		const event: NgGridItemEvent = this.getEventOutput();
+		this._renderer.setElementStyle(this._ngEl.nativeElement, "z-index", String(++this._ngGrid.zIndex));
 		this.onResizeStart.emit(event);
 		this.onResizeAny.emit(event);
 		this.onChangeStart.emit(event);
@@ -140,6 +141,7 @@ export class NgGridItem implements OnInit, OnDestroy {
 	}
 	public onDragStartEvent(): void {
 		const event: NgGridItemEvent = this.getEventOutput();
+		this._renderer.setElementStyle(this._ngEl.nativeElement, "z-index", String(++this._ngGrid.zIndex));
 		this.onDragStart.emit(event);
 		this.onDragAny.emit(event);
 		this.onChangeStart.emit(event);

--- a/src/interfaces/INgGrid.ts
+++ b/src/interfaces/INgGrid.ts
@@ -20,6 +20,7 @@ export interface NgGridConfig {
 	prefer_new?: boolean;
 	zoom_on_drag?: boolean;
 	limit_to_screen?: boolean;
+	allowOverlap?: boolean;
 }
 
 export interface NgGridItemConfig {


### PR DESCRIPTION
added feature gridItem overlap. 
By default this feature is disabled.
This can be enabled by setting 'allow_overlap': true in NgGridConfig