### PR TITLE
Use explicit exports in main file

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-export * from './directives/NgGrid';
-export * from './directives/NgGridItem';
-export * from './components/NgGridPlaceholder';
-export * from './interfaces/INgGrid';
-export * from './modules/NgGrid.module';
+export { NgGrid } from './directives/NgGrid';
+export { NgGridItem } from './directives/NgGridItem';
+export { NgGridPlaceholder } from './components/NgGridPlaceholder';
+export { NgGridConfig, NgGridItemConfig, NgGridItemEvent, NgGridItemSize, NgGridItemPosition, NgGridRawPosition, NgGridItemDimensions } from './interfaces/INgGrid';
+export { NgGridModule } from './modules/NgGrid.module';


### PR DESCRIPTION
Build process fails when configured to run with JIT compiler (`ng build --no-aot --prod`). For some reason exports must explicitly be defined. #254