### PR TITLE
Don't allow resizing of item be larger than max cols

### DIFF
--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -1007,7 +1007,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	}
 
 	private _isWithinBoundsX(pos: NgGridItemPosition, dims: NgGridItemSize) {
-		return (this._maxCols == 0 || pos.col == 1 || (pos.col + dims.x - 1) <= this._maxCols);
+		return (this._maxCols == 0 || (pos.col + dims.x - 1) <= this._maxCols);
 	}
 
 	private _fixPosToBoundsX(pos: NgGridItemPosition, dims: NgGridItemSize): NgGridItemPosition {


### PR DESCRIPTION
This fixes a bug which allows the item in first column to be resized to be larger than the grid.