### PR TITLE
Add center_to_screen option to be used with limit_to_screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To configure the grid with your own options, it is as easy as adding them as the
     'maintain_ratio': false,    //  Attempts to maintain aspect ratio based on the colWidth/rowHeight values set in the config
     'prefer_new': false,        //  When adding new items, will use that items position ahead of existing items
     'limit_to_screen': false,   //  When resizing the screen, with this true and auto_resize false, the grid will re-arrange to fit the screen size. Please note, at present this only works with cascade direction up.
+    'center_to_screen': false,  //  When resizing the screen, with this true and limit_to_screen true, the grid will center itself to the screen if max columns width is smaller than the grid width.
 }
 ```
 

--- a/src/components/NgGridPlaceholder.ts
+++ b/src/components/NgGridPlaceholder.ts
@@ -83,7 +83,7 @@ export class NgGridPlaceholder implements OnInit {
 	}
 
 	private _recalculatePosition(): void {
-		const x: number = (this._ngGrid.colWidth + this._ngGrid.marginLeft + this._ngGrid.marginRight) * (this._position.col - 1) + this._ngGrid.marginLeft;
+		const x: number = (this._ngGrid.colWidth + this._ngGrid.marginLeft + this._ngGrid.marginRight) * (this._position.col - 1) + this._ngGrid.marginLeft + this._ngGrid.screenMargin;
 		const y: number = (this._ngGrid.rowHeight + this._ngGrid.marginTop + this._ngGrid.marginBottom) * (this._position.row - 1) + this._ngGrid.marginTop;
 		this._setPosition(x, y);
 	}

--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -37,6 +37,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	public marginRight: number = 10;
 	public marginBottom: number = 10;
 	public marginLeft: number = 10;
+	public screenMargin: number = 0;
 	public isDragging: boolean = false;
 	public isResizing: boolean = false;
 	public autoStyle: boolean = true;
@@ -72,6 +73,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	private _preferNew: boolean = false;
 	private _zoomOnDrag: boolean = false;
 	private _limitToScreen: boolean = false;
+	private _centerToScreen: boolean = false;
 	private _curMaxRow: number = 0;
 	private _curMaxCol: number = 0;
 	private _dragReady: boolean = false;
@@ -99,6 +101,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 		prefer_new: false,
 		zoom_on_drag: false,
 		limit_to_screen: false,
+		center_to_screen: false,
 		element_based_row_height: false,
 	};
 	private _config = NgGrid.CONST_DEFAULT_CONFIG;
@@ -210,6 +213,9 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 					if (this._limitToScreen) {
 						this._maxCols = this._getContainerColumns();
 					}
+					break;
+				case 'center_to_screen':
+					this._centerToScreen = val ? true : false;
 					break;
 				case 'element_based_row_height':
 					this._elementBasedDynamicRowHeight = !!val;
@@ -387,7 +393,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 			}
 		}
 
-		if (this._autoResize) {
+		if (this._autoResize || (this._limitToScreen && this._centerToScreen)) {
 			for (let item of this._items) {
 				item.recalculateSelf();
 			}
@@ -1176,7 +1182,14 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 
 	private _getContainerColumns(): number {
 		const maxWidth: number = this._ngEl.nativeElement.getBoundingClientRect().width;
-		return Math.floor(maxWidth / (this.colWidth + this.marginLeft + this.marginRight));
+		const itemWidth: number = this.colWidth + this.marginLeft + this.marginRight;
+		const maxCols: number = Math.floor(maxWidth / itemWidth);
+
+		if (this._centerToScreen) {
+			this.screenMargin = Math.floor((maxWidth - (maxCols * itemWidth)) / 2);
+		}
+
+		return maxCols;
 	}
 
 	private _getContainerRows(): number {

--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -391,9 +391,15 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 				this.updatePositionsAfterMaxChange();
 				this._cascadeGrid();
 			}
+
+			if (this._centerToScreen) {
+				for (let item of this._items) {
+					item.recalculateSelf();
+				}
+			}
 		}
 
-		if (this._autoResize || (this._limitToScreen && this._centerToScreen)) {
+		if (this._autoResize) {
 			for (let item of this._items) {
 				item.recalculateSelf();
 			}

--- a/src/directives/NgGridItem.ts
+++ b/src/directives/NgGridItem.ts
@@ -481,7 +481,7 @@ export class NgGridItem implements OnInit, OnDestroy {
 	}
 
 	private _recalculatePosition(): void {
-		const x: number = (this._ngGrid.colWidth + this._ngGrid.marginLeft + this._ngGrid.marginRight) * (this._currentPosition.col - 1) + this._ngGrid.marginLeft;
+		const x: number = (this._ngGrid.colWidth + this._ngGrid.marginLeft + this._ngGrid.marginRight) * (this._currentPosition.col - 1) + this._ngGrid.marginLeft + this._ngGrid.screenMargin;
 		const y: number = (this._ngGrid.rowHeight + this._ngGrid.marginTop + this._ngGrid.marginBottom) * (this._currentPosition.row - 1) + this._ngGrid.marginTop;
 
 		this.setPosition(x, y);

--- a/src/interfaces/INgGrid.ts
+++ b/src/interfaces/INgGrid.ts
@@ -20,6 +20,7 @@ export interface NgGridConfig {
 	prefer_new?: boolean;
 	zoom_on_drag?: boolean;
 	limit_to_screen?: boolean;
+	center_to_screen?: boolean;
 	element_based_row_height?: boolean;
 }
 


### PR DESCRIPTION
This adds new center_to_screen configuration option which will center the grid to the screen when using limit_to_screen. This is done by calculating screenMargin which is used in calculating the position for the placeholder / items.