### PR TITLE
Manage listeners in order to load them when needed

### DIFF
--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -9,7 +9,10 @@ import 'rxjs/add/observable/fromEvent';
 
 @Directive({
 	selector: '[ngGrid]',
-	inputs: ['config: ngGrid']
+	inputs: ['config: ngGrid'],
+	host: {
+		'(window:resize)': 'resizeEventHandler($event)',
+	}
 })
 export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	//	Event Emitters
@@ -82,7 +85,6 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 	private _touchstart$: Observable<TouchEvent>;
 	private _touchmove$: Observable<TouchEvent>;
 	private _touchend$: Observable<TouchEvent>;
-	private _resize$: Observable<any>;
 	private _subscriptions: Subscription[] = [];
 
 	private _enabledListener: boolean = false;
@@ -134,8 +136,6 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 
 	//	Public methods
 	public ngOnInit(): void {
-		this._enableResizeListeners();
-
 		this._renderer.setElementClass(this._ngEl.nativeElement, 'grid', true);
 		if (this.autoStyle) this._renderer.setElementStyle(this._ngEl.nativeElement, 'position', 'relative');
 		this.setConfig(this._config);
@@ -1277,7 +1277,6 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 		this._touchstart$ = Observable.fromEvent(element, 'touchstart', eventOptions);
 		this._touchmove$ = Observable.fromEvent(element, 'touchmove', eventOptions);
 		this._touchend$ = Observable.fromEvent(element, 'touchend', eventOptions);
-		this._resize$ = Observable.fromEvent(window, 'resize');
 	}
 	
 	private _enableListeners(): void {
@@ -1329,11 +1328,5 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 			mousemoveSubs,
 			mouseupSubs
 		);
-	}
-
-	private _enableResizeListeners(): void {
-		const resizeSubs = this._resize$.subscribe((e: MouseEvent) => this.resizeEventHandler(e));
-
-		this._subscriptions.push(resizeSubs);
 	}
 }

--- a/src/directives/NgGrid.ts
+++ b/src/directives/NgGrid.ts
@@ -1267,16 +1267,15 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
 
 	private _defineListeners(): void {
 		const element = this._ngEl.nativeElement;
-		const eventOptions = { passive: true };
 
-		this._documentMousemove$ = Observable.fromEvent(document, 'mousemove', eventOptions);
-		this._documentMouseup$ = Observable.fromEvent(document, 'mouseup', eventOptions);
-		this._mousedown$ = Observable.fromEvent(element, 'mousedown', eventOptions);
-		this._mousemove$ = Observable.fromEvent(element, 'mousemove', eventOptions);
-		this._mouseup$ = Observable.fromEvent(element, 'mouseup', eventOptions);
-		this._touchstart$ = Observable.fromEvent(element, 'touchstart', eventOptions);
-		this._touchmove$ = Observable.fromEvent(element, 'touchmove', eventOptions);
-		this._touchend$ = Observable.fromEvent(element, 'touchend', eventOptions);
+		this._documentMousemove$ = Observable.fromEvent(document, 'mousemove');
+		this._documentMouseup$ = Observable.fromEvent(document, 'mouseup');
+		this._mousedown$ = Observable.fromEvent(element, 'mousedown');
+		this._mousemove$ = Observable.fromEvent(element, 'mousemove');
+		this._mouseup$ = Observable.fromEvent(element, 'mouseup');
+		this._touchstart$ = Observable.fromEvent(element, 'touchstart');
+		this._touchmove$ = Observable.fromEvent(element, 'touchmove');
+		this._touchend$ = Observable.fromEvent(element, 'touchend');
 	}
 	
 	private _enableListeners(): void {


### PR DESCRIPTION
I'm using your library in order to display some widgets within a dashboard. Since the dashboard in my app is just for displaying information (there is no way to edit the position and size of the widgets) it doesn't make sense to load some listeners that are not going to be fired.

AFAIK there is no "angular" way to attach/detach listeners conditionally (angular/angular#7626). It seems it won't be implemented in short time so I just implemented this solution as proposed in the thread.

I experienced an improvement in terms of performance so I guess it could be useful for others. @BTMorton I have tried to add some unit tests but I'm unable to run them locally. Am I missing something? Maybe you can give me a clue about that. Thanks in advance.

Please let me know your questions/concerns.